### PR TITLE
implement rfc status code details

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -317,6 +317,7 @@ mod tests {
                 kind: ParamKind::STRING,
                 required: true,
             }]),
+            body_params: None,
         };
         let client = Client::new(server.url().as_str());
         let state = EndpointHandler { endpoint, client };
@@ -330,6 +331,7 @@ mod tests {
             Path(vec![].into_iter().collect()),
             State(state),
             Query(query_parameters),
+            None,
         )
         .await
         .into_response()
@@ -378,6 +380,7 @@ mod tests {
                 kind: ParamKind::STRING,
                 required: true,
             }]),
+            body_params: None,
         };
         let client = Client::new(server.url().as_str());
         let state = EndpointHandler { endpoint, client };
@@ -391,6 +394,7 @@ mod tests {
             Path(vec![].into_iter().collect()),
             State(state),
             Query(query_parameters),
+            None,
         )
         .await
         .into_response()


### PR DESCRIPTION
Adds the RFC note about 200 vs 206 vs 500 states. 

The only difference from the RFC is respecting differences in status codes from the router- e.g. if a router returns a 401, it'll respect that over the current mapping. The only exclusions are 200/400 per spec. 